### PR TITLE
use long flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ prometheus_bind_exporter_src_access:
 For typical deployment you can eventually define enable ufw fw and define src access list
 Based on defined variables you can set variables common for all prometheus stack
 
+In isolated environments, you may need to set a proxy for http requestsd. Define environment variables pointing to your proxy as shown below
+
+```yaml
+# here we make a variable named "proxy_env" that is a dictionary
+proxy_env:
+  http_proxy: http://proxy.example.com:8080
+  https_proxy: http://proxy.example.com:8080
+```
+
 Dependencies
 ------------
 

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -17,7 +17,7 @@ prometheus_bind_exporter_loglevel: '{{ prometheus_loglevel }}'
 prometheus_bind_exporter_weblisten: '{{ prometheus_bind_exporter_listen_ip }}:{{ prometheus_bind_exporter_listen_port }}'
 prometheus_bind_exporter_listen_port: '9119'
 prometheus_bind_exporter_listen_ip: ''
-prometheus_bind_exporter_version: '0.3.0'
+prometheus_bind_exporter_version: '0.6.0'
 prometheus_bind_exporter_targeturl: 'http://127.0.0.1:8053/'
 
 prometheus_bind_pid_file: '/run/named/named.pid'

--- a/tasks/install.yaml
+++ b/tasks/install.yaml
@@ -42,6 +42,9 @@
     - "{{ prometheus_bind_exporter_config_path }}"
 
 - name: download and untar bind_exporter tarball
+  environment:
+    http_proxy: "{{ proxy_env.http_proxy | default(None) }}"
+    https_proxy: "{{ proxy_env.https_proxy | default(None) }}"
   unarchive:
     src: "{{ prometheus_bind_exporter_tar_url }}"
     dest: "{{ prometheus_bind_exporter_install_path }}"

--- a/templates/bind_exporter.defaults.j2
+++ b/templates/bind_exporter.defaults.j2
@@ -4,8 +4,8 @@ START=yes
 
 #
 STARTUP_ARGS=" \
-      -bind.stats-groups server,view,tasks \
-      -bind.pid-file {{ prometheus_bind_pid_file }} \
-      -bind.stats-url {{ prometheus_bind_exporter_targeturl }} \
-      -web.listen-address {{ prometheus_bind_exporter_weblisten }} \
+      --bind.stats-groups server,view,tasks \
+      --bind.pid-file {{ prometheus_bind_pid_file }} \
+      --bind.stats-url {{ prometheus_bind_exporter_targeturl }} \
+      --web.listen-address {{ prometheus_bind_exporter_weblisten }} \
       "


### PR DESCRIPTION
- since 0.4.0 bind_exporter uses long flags (kingpin.v2)
- use release 0.6.0 by default